### PR TITLE
Add MaxIDE-style build file locking (#2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"onCommand:blitzmax.toggleBuildOption",
 		"onCommand:blitzmax.pickBlitzMaxPath",
 		"onCommand:blitzmax.setSourceFile",
+		"onCommand:blitzmax.unlockSourceFile",
 		"onCommand:blitzmax.build",
 		"onCommand:blitzmax.buildAndRun",
 		"onCommand:blitzmax.buildAndDebug",
@@ -530,8 +531,14 @@
 			},
 			{
 				"command": "blitzmax.setSourceFile",
-				"title": "Set As Default Build Task Source File",
+				"title": "Lock Current File for Building",
 				"category": "BlitzMax"
+			},
+			{
+				"command": "blitzmax.unlockSourceFile",
+				"title": "Unlock Build File",
+				"category": "BlitzMax",
+				"icon": "$(unlock)"
 			},
 			{
 				"command": "blitzmax.build",
@@ -609,6 +616,10 @@
 				{
 					"command": "blitzmax.resetBuildOptions",
 					"when": "view == blitzmax-build-options"
+				},
+				{
+					"command": "blitzmax.unlockSourceFile",
+					"when": "view == blitzmax-build-options && blitzmax:buildFileLocked"
 				}
 			],
 			"view/item/context": [
@@ -762,7 +773,7 @@
 							"source": {
 								"type": "string",
 								"default": "${file}",
-								"markdownDescription": "Absolute path to root source file  \n`bmk <source>`  \n[More info](https://blitzmax.org/docs/en/tools/bmk/#command-line-syntax)"
+								"markdownDescription": "Build root source file. Use `${file}` to build the active editor file, or choose a `.bmx` file to lock builds to that application root.  \n`bmk <source>`  \n[More info](https://blitzmax.org/docs/en/tools/bmk/#command-line-syntax)"
 							},
 							"fullcompile": {
 								"type": "boolean",
@@ -997,7 +1008,7 @@
 					"source": {
 						"type": "string",
 						"default": "${file}",
-						"markdownDescription": "Absolute path to root source file  \n`bmk <source>`  \n[More info](https://blitzmax.org/docs/en/tools/bmk/#command-line-syntax)"
+						"markdownDescription": "Build root source file. Use `${file}` to build the active editor file, or choose a `.bmx` file to lock builds to that application root.  \n`bmk <source>`  \n[More info](https://blitzmax.org/docs/en/tools/bmk/#command-line-syntax)"
 					},
 					"fullcompile": {
 						"type": "boolean",

--- a/src/buildtree.ts
+++ b/src/buildtree.ts
@@ -9,7 +9,9 @@ import {
 	internalBuildDefinition,
 	BmxBuildTaskDefinition,
 	makeTaskDefinition,
-	getFirstBlitzMaxWorkspace
+	getFirstBlitzMaxWorkspace,
+	isBuildFileLocked,
+	workspaceFolderVariable
 } from './taskprovider'
 
 let CurrentWorkspace: vscode.WorkspaceFolder | undefined = undefined
@@ -56,12 +58,26 @@ export function registerBuildTreeProvider( context: vscode.ExtensionContext ) {
 
 		// Figure out relative path if we have a workspace
 		if ( workspace ) // we could use path.join here, but I think / looks better in json
-			sourcePath = '${workspaceFolder}' + '/' + path.relative( workspace.uri.fsPath, sourcePath )
+			sourcePath = workspaceFolderVariable( workspace ) + '/' + path.relative( workspace.uri.fsPath, sourcePath ).split( path.sep ).join( '/' )
 
 		// Update task
-		const definition = getBuildDefinitionFromWorkspace( CurrentWorkspace )
+		let definition = getBuildDefinitionFromWorkspace( workspace )
+		if ( definition === internalBuildDefinition ) definition = Object.assign( {}, definition )
 		definition.source = sourcePath
-		saveAsDefaultTaskDefinition( definition, CurrentWorkspace )
+		saveAsDefaultTaskDefinition( definition, workspace )
+		bmxBuildTreeProvider.refresh()
+		vscode.window.showInformationMessage( `Build file locked to ${path.basename( sourcePath )}.` )
+	} ) )
+
+	context.subscriptions.push( vscode.commands.registerCommand( 'blitzmax.unlockSourceFile', () => {
+		const document = vscode.window.activeTextEditor?.document
+		const workspace = ( document ? vscode.workspace.getWorkspaceFolder( document.uri ) : undefined ) || CurrentWorkspace
+		let definition = getBuildDefinitionFromWorkspace( workspace )
+		if ( definition === internalBuildDefinition ) definition = Object.assign( {}, definition )
+		definition.source = '${file}'
+		saveAsDefaultTaskDefinition( definition, workspace )
+		bmxBuildTreeProvider.refresh()
+		vscode.window.showInformationMessage( 'Build file unlocked. BlitzMax will build the active editor file.' )
 	} ) )
 
 	context.subscriptions.push( vscode.commands.registerCommand( 'blitzmax.toggleBuildOption', async ( option: any ) => {
@@ -113,7 +129,9 @@ export class BmxBuildTreeProvider implements vscode.TreeDataProvider<vscode.Tree
 	}
 
 	refresh() {
-		vscode.commands.executeCommand( 'setContext', 'blitzmax:debugging', getBuildDefinitionFromWorkspace( CurrentWorkspace ).debug )
+		const definition = getBuildDefinitionFromWorkspace( CurrentWorkspace )
+		vscode.commands.executeCommand( 'setContext', 'blitzmax:debugging', definition.debug )
+		vscode.commands.executeCommand( 'setContext', 'blitzmax:buildFileLocked', isBuildFileLocked( definition ) )
 		this._onDidChangeTreeData.fire( null )
 	}
 
@@ -211,10 +229,20 @@ export class BmxBuildTreeProvider implements vscode.TreeDataProvider<vscode.Tree
 	generateAllBuildCategories(): Promise<vscode.TreeItem[]> {
 
 		const def = getBuildDefinitionFromWorkspace( CurrentWorkspace )
+		const buildFileLocked = isBuildFileLocked( def )
+		const buildFile = this.createChildItem(
+			true,
+			'root_file',
+			'Build File',
+			'Controls which `.bmx` file is used by Build, Build and Run, and debugging. Compatible language servers also use a locked file as the project-analysis root.  \nWhen unlocked, BlitzMax builds the active editor file. Lock a file to always use it as the application root.',
+			buildFileLocked ? def.source + ' (locked)' : 'Active editor file (unlocked)'
+		)
+		buildFile.iconPath = new vscode.ThemeIcon( buildFileLocked ? 'lock' : 'unlock' )
+		vscode.commands.executeCommand( 'setContext', 'blitzmax:buildFileLocked', buildFileLocked )
 
 		this.buildCategories = [
 			// No category root items
-			this.createChildItem( true, 'root_file', 'Source File', "Absolute path to root source file  \n`bmk <source>`  \n[More info](https://blitzmax.org/docs/en/tools/bmk/#command-line-syntax)", def.source ),
+			buildFile,
 
 			{ id: 'build', label: 'Build Options', collapsibleState: vscode.TreeItemCollapsibleState.Expanded },
 			{ id: 'app', label: 'App Options', collapsibleState: vscode.TreeItemCollapsibleState.Expanded },
@@ -360,7 +388,7 @@ export async function toggleBuildOptions( definition: BmxBuildTaskDefinition | u
 		case 'root_file':
 			await vscode.window.showInputBox(
 				{
-					prompt: 'Absolute path to root source file',
+					prompt: 'Build root source file. Clear this value to build the active editor file.',
 					value: definition.source != '${file}'
 						? definition.source
 						: vscode.window.activeTextEditor?.document.uri.fsPath

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode'
 import { existsSync } from './common'
 import * as lsp from 'vscode-languageclient/node'
 import { workspaceOrGlobalConfigBoolean, workspaceOrGlobalConfigArray, workspaceOrGlobalConfigString } from './common'
+import { lockedBuildSourcePath } from './taskprovider'
 let multiInstance: boolean | undefined
 let forcedStop: boolean
 let outputChannel: vscode.LogOutputChannel
@@ -87,6 +88,7 @@ export function activeLspCapabilities(): lsp.ServerCapabilities {
 // server would take literally
 interface BmxLspSettings {
 	sdkPath?: string
+	rootSourcePath: string
 	buildMode?: string
 	targetPlatform?: string
 	targetArchitecture?: string
@@ -98,7 +100,7 @@ interface BmxLspSettings {
 
 function lspSettingsFor( workspace: vscode.WorkspaceFolder | undefined ): BmxLspSettings {
 
-	const settings: BmxLspSettings = {}
+	const settings: BmxLspSettings = { rootSourcePath: lockedBuildSourcePath( workspace ) }
 
 	const sdkPath = workspaceOrGlobalConfigString( workspace, 'blitzmax.base.path' )
 	if ( sdkPath ) settings.sdkPath = sdkPath
@@ -301,7 +303,7 @@ export function registerLSP( context: vscode.ExtensionContext ) {
 			return
 		}
 
-		if ( event.affectsConfiguration( 'blitzmax.lsp' ) ) sendSettingsToAllLSP()
+		if ( event.affectsConfiguration( 'blitzmax.lsp' ) || event.affectsConfiguration( 'tasks' ) ) sendSettingsToAllLSP()
 	} )
 	
 	// Notify about multi instance reload

--- a/src/taskprovider.ts
+++ b/src/taskprovider.ts
@@ -130,6 +130,45 @@ export function getBuildDefinitionFromWorkspace( workspace: vscode.WorkspaceFold
 	return internalBuildDefinition
 }
 
+export function isBuildFileLocked( definition: BmxBuildTaskDefinition | undefined ): boolean {
+	return !!definition && !!definition.source && definition.source !== '${file}'
+}
+
+export function workspaceFolderVariable( workspace: vscode.WorkspaceFolder ): string {
+	const folders = vscode.workspace.workspaceFolders
+	if ( folders && folders.length > 1 ) return '${workspaceFolder:' + workspace.name + '}'
+	return '${workspaceFolder}'
+}
+
+// The build task remains the single source of truth. The language server cannot
+// expand VS Code task variables itself, so pass it an absolute path only when
+// the task names a stable build file. An empty path means "follow the active
+// source", matching the unlocked MaxIDE-style workflow.
+export function lockedBuildSourcePath( workspace: vscode.WorkspaceFolder | undefined ): string {
+	if ( !workspace ) return ''
+	const definition = getBuildDefinitionFromWorkspace( workspace )
+	if ( !isBuildFileLocked( definition ) ) return ''
+	let unresolvedVariable = false
+	let source = definition.source.replace( /\$\{workspaceFolder(?::([^}]+))?\}/g, ( original, folderName: string | undefined ) => {
+		let sourceWorkspace = workspace
+		if ( folderName ) {
+			const folders = vscode.workspace.workspaceFolders
+			const namedWorkspace = folders ? folders.find( folder => folder.name === folderName ) : undefined
+			if ( !namedWorkspace ) {
+				unresolvedVariable = true
+				return original
+			}
+			sourceWorkspace = namedWorkspace
+		}
+		return sourceWorkspace.uri.fsPath
+	} )
+	if ( unresolvedVariable ) return ''
+	if ( source.includes( '${' ) ) return ''
+	if ( !path.isAbsolute( source ) ) source = path.resolve( workspace.uri.fsPath, source )
+	if ( path.extname( source ).toLowerCase() !== '.bmx' ) return ''
+	return vscode.Uri.file( source ).fsPath
+}
+
 export function saveAsDefaultTaskDefinition( newDef: BmxBuildTaskDefinition | undefined, workspace: vscode.WorkspaceFolder | undefined ): boolean {
 
 	if ( !newDef ) return false
@@ -146,7 +185,7 @@ export function saveAsDefaultTaskDefinition( newDef: BmxBuildTaskDefinition | un
 	}
 
 	// Try to update the task with the same label
-	const tasksFile = vscode.workspace.getConfiguration( 'tasks' )
+	const tasksFile = vscode.workspace.getConfiguration( 'tasks', workspace )
 	const tasksList: BmxBuildTaskDefinition[] | undefined = tasksFile.get( 'tasks' )
 	
 	if ( tasksList ) {

--- a/walkthroughs/build_options.md
+++ b/walkthroughs/build_options.md
@@ -15,6 +15,23 @@ Hover your mouse over an item to display more information.
 * _The build options view is displaying your default build task in `.vscode/tasks.json`.\
 Read more in the "Building & Tasks" step._
 
+# Locking the build file
+
+The **Build File** at the top of the view controls which `.bmx` file is used by
+Build, Build and Run, and debugging. Compatible language servers also use a
+locked file as the project-analysis root.
+
+By default it displays **Active editor file (unlocked)**. This is equivalent to
+MaxIDE without a locked file: whichever source file is active is built.
+
+Use **BlitzMax: Lock Current File for Building** from the editor or Explorer
+context menu to make that file the application root. The view then displays its
+path followed by **(locked)**. This is equivalent to locking a file in MaxIDE.
+
+Use **BlitzMax: Unlock Build File** to return to building the active editor file.
+The extension stores the same setting in the default BlitzMax task's `source`
+field, so existing `.vscode/tasks.json` files remain compatible.
+
 # Multiple build options
 
 Click the cogwheel to select a new build task or create a new one.


### PR DESCRIPTION
Cleared up the language around build files and the concept of "locking", to be more familiar to users coming from MaxIDE.
Added a bit more metadata for the LSP for determining project "roots", to help with analysis, etc.